### PR TITLE
Add alias support for entity search

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,24 @@ For a complete working example, see the [Quickstart Example](./examples/quicksta
 
 The example is fully documented with clear explanations of each functionality and includes a comprehensive README with setup instructions and next steps.
 
+## Seeding Assets with Aliases
+
+Including aliases when seeding nodes ensures new mentions resolve to the correct entity.
+
+```python
+from graphiti_core.nodes import EntityNode
+
+btc = EntityNode(
+    name="BTC",
+    group_id="crypto",
+    aliases=["Bitcoin"],
+)
+await btc.generate_name_embedding(graphiti.embedder)
+await btc.save(graphiti.driver)
+```
+
+When an episode later mentions "Bitcoin" Graphiti links it to the existing `BTC` node rather than creating a duplicate.
+
 ## MCP Server
 
 The `mcp_server` directory contains a Model Context Protocol (MCP) server implementation for Graphiti. This server allows AI assistants to interact with Graphiti's knowledge graph capabilities through the MCP protocol.

--- a/graphiti_core/graph_queries.py
+++ b/graphiti_core/graph_queries.py
@@ -19,6 +19,7 @@ from graphiti_core.models.nodes.node_db_queries import (
 # Mapping from Neo4j fulltext index names to FalkorDB node labels
 NEO4J_TO_FALKORDB_MAPPING = {
     'node_name_and_summary': 'Entity',
+    'node_name_summary_and_aliases': 'Entity',
     'community_name': 'Community',
     'episode_content': 'Episodic',
     'edge_name_and_fact': 'RELATES_TO',
@@ -69,19 +70,21 @@ def get_fulltext_indices(db_type: str = 'neo4j') -> list[LiteralString]:
     if db_type == 'falkordb':
         return [
             """CREATE FULLTEXT INDEX FOR (e:Episodic) ON (e.content, e.source, e.source_description, e.group_id)""",
-            """CREATE FULLTEXT INDEX FOR (n:Entity) ON (n.name, n.summary, n.group_id)""",
+            """CREATE FULLTEXT INDEX FOR (n:Entity) ON (n.name, n.aliases, n.summary, n.group_id)""",
             """CREATE FULLTEXT INDEX FOR (n:Community) ON (n.name, n.group_id)""",
             """CREATE FULLTEXT INDEX FOR ()-[e:RELATES_TO]-() ON (e.name, e.fact, e.group_id)""",
         ]
     else:
         return [
-            """CREATE FULLTEXT INDEX episode_content IF NOT EXISTS 
+            """CREATE FULLTEXT INDEX episode_content IF NOT EXISTS
             FOR (e:Episodic) ON EACH [e.content, e.source, e.source_description, e.group_id]""",
-            """CREATE FULLTEXT INDEX node_name_and_summary IF NOT EXISTS 
+            """CREATE FULLTEXT INDEX node_name_and_summary IF NOT EXISTS
             FOR (n:Entity) ON EACH [n.name, n.summary, n.group_id]""",
-            """CREATE FULLTEXT INDEX community_name IF NOT EXISTS 
+            """CREATE FULLTEXT INDEX node_name_summary_and_aliases IF NOT EXISTS
+            FOR (n:Entity) ON EACH [n.name, n.aliases, n.summary, n.group_id]""",
+            """CREATE FULLTEXT INDEX community_name IF NOT EXISTS
             FOR (n:Community) ON EACH [n.name, n.group_id]""",
-            """CREATE FULLTEXT INDEX edge_name_and_fact IF NOT EXISTS 
+            """CREATE FULLTEXT INDEX edge_name_and_fact IF NOT EXISTS
             FOR ()-[e:RELATES_TO]-() ON EACH [e.name, e.fact, e.group_id]""",
         ]
 

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -43,8 +43,9 @@ ENTITY_NODE_RETURN: LiteralString = """
             n.uuid As uuid, 
             n.name AS name,
             n.group_id AS group_id,
-            n.created_at AS created_at, 
+            n.created_at AS created_at,
             n.summary AS summary,
+            n.aliases AS aliases,
             labels(n) AS labels,
             properties(n) AS attributes
             """
@@ -291,6 +292,7 @@ class EpisodicNode(Node):
 class EntityNode(Node):
     name_embedding: list[float] | None = Field(default=None, description='embedding of the name')
     summary: str = Field(description='regional summary of surrounding edges', default_factory=str)
+    aliases: list[str] = Field(default_factory=list, description='alternate names')
     attributes: dict[str, Any] = Field(
         default={}, description='Additional attributes of the node. Dependent on node labels'
     )
@@ -325,6 +327,7 @@ class EntityNode(Node):
             'name_embedding': self.name_embedding,
             'group_id': self.group_id,
             'summary': self.summary,
+            'aliases': self.aliases,
             'created_at': self.created_at,
         }
 
@@ -561,6 +564,7 @@ def get_entity_node_from_record(record: Any) -> EntityNode:
         labels=record['labels'],
         created_at=parse_db_date(record['created_at']),  # type: ignore
         summary=record['summary'],
+        aliases=record.get('aliases') or record['attributes'].get('aliases', []),
         attributes=record['attributes'],
     )
 
@@ -570,6 +574,7 @@ def get_entity_node_from_record(record: Any) -> EntityNode:
     entity_node.attributes.pop('name_embedding', None)
     entity_node.attributes.pop('summary', None)
     entity_node.attributes.pop('created_at', None)
+    entity_node.attributes.pop('aliases', None)
 
     return entity_node
 

--- a/graphiti_core/search/search_utils.py
+++ b/graphiti_core/search/search_utils.py
@@ -355,7 +355,7 @@ async def node_fulltext_search(
     filter_query, filter_params = node_search_filter_query_constructor(search_filter)
 
     query = (
-        get_nodes_query(driver.provider, 'node_name_and_summary', '$query')
+        get_nodes_query(driver.provider, 'node_name_summary_and_aliases', '$query')
         + """
         YIELD node AS n, score
             WITH n, score
@@ -721,7 +721,7 @@ async def get_relevant_nodes(
         WHERE score > $min_score
         WITH node, collect(n)[..$limit] AS top_vector_nodes, collect(n.uuid) AS vector_node_uuids
         """
-        + get_nodes_query(driver.provider, 'node_name_and_summary', 'node.fulltext_query')
+        + get_nodes_query(driver.provider, 'node_name_summary_and_aliases', 'node.fulltext_query')
         + """
         YIELD node AS m
         WHERE m.group_id = $group_id

--- a/tests/test_node_int.py
+++ b/tests/test_node_int.py
@@ -42,6 +42,7 @@ def sample_entity_node():
         labels=['Entity'],
         name_embedding=[0.5] * 1024,
         summary='Entity Summary',
+        aliases=['Alias'],
     )
 
 
@@ -78,6 +79,7 @@ async def test_entity_node_save_get_and_delete(sample_entity_node):
     assert retrieved.uuid == sample_entity_node.uuid
     assert retrieved.name == 'Test Entity'
     assert retrieved.group_id == 'test_group'
+    assert retrieved.aliases == ['Alias']
 
     await sample_entity_node.delete(neo4j_driver)
 


### PR DESCRIPTION
## Summary
- create new alias-aware index in `graph_queries`
- include alias index in search utils
- persist `aliases` on `EntityNode`
- update node integration test with aliases
- document seeding nodes with aliases in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6859147cb5d48326a867b6c185002ccc